### PR TITLE
Add `fix_requirements` action

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,47 @@
 # Travel Task for Google Artifact Registry
 
 A Travel task to download/upload a Python package from/to Google Artifact Registry using pip
+
+## Upload
+
+To upload a package to Google Artifact Registry using the task, add the following config to a Travel `bag.yml`:
+
+```yml
+tasks:
+  takeoff:
+    instead:
+      - task: traveltask_google_artifact_registry==0.0.1
+        name: upload-to-some-registry
+        config:
+          project: <project>
+          region: <region>
+          repository: <repository>
+          action: upload
+```
+
+## Installation
+
+To install a package from Google Artifact Registry using the task, add the following config to a Travel `bag.yml`:
+
+```yml
+tasks:
+  setup:
+    pre:
+      - task: traveltask_google_artifact_registry==0.0.1
+        name: download-from-some-registry
+        config:
+          project: <project>
+          region: <region>
+          repository: <repository>
+          action: install
+          packages: <package>[=<version>]
+          
+    post:
+      - task: traveltask_google_artifact_registry==0.0.1
+        name: fix-requirements
+        config:
+          project: <project>
+          region: <region>
+          repository: <repository>
+          action: fix_requirements
+```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To upload a package to Google Artifact Registry using the task, add the followin
 tasks:
   takeoff:
     instead:
-      - task: traveltask_google_artifact_registry==0.0.1
+      - task: traveltask_google_artifact_registry
         name: upload-to-some-registry
         config:
           project: <project>
@@ -27,7 +27,7 @@ To install a package from Google Artifact Registry using the task, add the follo
 tasks:
   setup:
     pre:
-      - task: traveltask_google_artifact_registry==0.0.1
+      - task: traveltask_google_artifact_registry
         name: download-from-some-registry
         config:
           project: <project>
@@ -37,7 +37,7 @@ tasks:
           packages: <package>[=<version>]
           
     post:
-      - task: traveltask_google_artifact_registry==0.0.1
+      - task: traveltask_google_artifact_registry
         name: fix-requirements
         config:
           project: <project>
@@ -45,3 +45,5 @@ tasks:
           repository: <repository>
           action: fix_requirements
 ```
+
+**N.B.:** In the above example, the Google Artifact Registry config must match between the stages

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Travel Task for Google Artifact Registry
 
-A Travel Task to download/upload a Python package from/to Google Artifact Registry using Pip
+A Travel task to download/upload a Python package from/to Google Artifact Registry using pip

--- a/src/traveltask_google_artifact_registry/package/setup.py
+++ b/src/traveltask_google_artifact_registry/package/setup.py
@@ -13,7 +13,7 @@ _NAME = "traveltask_google_artifact_registry"
 setup(
     name=_NAME,
     version="0.0.0",
-    description="A Travel Task to download/upload a Python package from/to Google Artifact Registry using Pip",
+    description="A Travel task to download/upload a Python package from/to Google Artifact Registry using pip",
     packages=find_packages(),
     include_package_data=True,
     install_requires=requirements

--- a/src/traveltask_google_artifact_registry/package/setup.py
+++ b/src/traveltask_google_artifact_registry/package/setup.py
@@ -1,20 +1,19 @@
-from setuptools import setup, find_packages
 import os
+from setuptools import setup, find_packages
 
 
-# Read requirements
 requirements_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "requirements.txt")
-with open(requirements_file, "r") as f:
-    requirements = f.read().splitlines()
 
 
-# Package configuration
-_NAME = "traveltask_google_artifact_registry"
-setup(
-    name=_NAME,
-    version="0.0.0",
-    description="A Travel task to download/upload a Python package from/to Google Artifact Registry using pip",
-    packages=find_packages(),
-    include_package_data=True,
-    install_requires=requirements
-)
+if __name__ == "__main__":
+    with open(requirements_file, "rt") as f:
+        requirements = f.read().splitlines()
+    
+    setup(
+        description="A Travel task to download/upload a Python package from/to Google Artifact Registry using pip",
+        include_package_data=True,
+        install_requires=requirements,
+        name="traveltask_google_artifact_registry",
+        packages=find_packages(),
+        version="0.0.0",
+    )

--- a/src/traveltask_google_artifact_registry/package/traveltask_google_artifact_registry/config.py
+++ b/src/traveltask_google_artifact_registry/package/traveltask_google_artifact_registry/config.py
@@ -12,5 +12,5 @@ class TaskConfig:
     project: str
     region: str
     repository: str
-    action: str  # Can be upload or install
+    action: str  # Can be upload or install or fix_requirements
     packages: str = None

--- a/src/traveltask_google_artifact_registry/package/traveltask_google_artifact_registry/config.py
+++ b/src/traveltask_google_artifact_registry/package/traveltask_google_artifact_registry/config.py
@@ -12,5 +12,5 @@ class TaskConfig:
     project: str
     region: str
     repository: str
-    action: str  # Can be upload or install or fix_requirements
+    action: str  # Can be upload, install or fix_requirements
     packages: str = None

--- a/src/traveltask_google_artifact_registry/package/traveltask_google_artifact_registry/task.py
+++ b/src/traveltask_google_artifact_registry/package/traveltask_google_artifact_registry/task.py
@@ -11,9 +11,6 @@ from travel.tools.venv import Virtualenv
 from traveltask_google_artifact_registry.config import TaskConfig
 
 
-PyPI_keyrings_google_artifact_registry_auth = "keyrings.google-artifactregistry-auth"
-
-
 def _get_index_url(config: TaskConfig):
     return f"https://{config.region}-python.pkg.dev/{config.project}/{config.repository}/"
 
@@ -28,16 +25,6 @@ def _fix_venv_requirements(env: BaseVirtualenv, index_url: str) -> None:
         
     with open(env.requirements_file, "rt") as f:
         requirements = f.read().splitlines()
-        
-    has_keyrings = False
-    
-    for requirement in requirements:
-        if PyPI_keyrings_google_artifact_registry_auth in requirement:
-            has_keyrings = True
-            break
-
-    if not has_keyrings:
-        requirements.append(PyPI_keyrings_google_artifact_registry_auth)
         
     requirements.insert(0, f"--extra-index-url {index_url}")
     

--- a/src/traveltask_google_artifact_registry/package/traveltask_google_artifact_registry/task.py
+++ b/src/traveltask_google_artifact_registry/package/traveltask_google_artifact_registry/task.py
@@ -3,6 +3,7 @@ import sys
 
 from travel.config.bag import Bag
 from travel.config.reader import parse_bags
+from travel.tools.base_venv import BaseVirtualenv
 from travel.tools.pip import Pip
 from travel.tools.python import Python
 from travel.tools.venv import Virtualenv
@@ -17,12 +18,10 @@ def _get_index_url(config: TaskConfig):
     return f"https://{config.region}-python.pkg.dev/{config.project}/{config.repository}/"
 
 
-def _fix_requirements(bag: Bag, python: Python, config: TaskConfig) -> None:
-    # Get the right venv
-    env = Virtualenv(bag)
-    
+def _fix_venv_requirements(env: BaseVirtualenv, index_url: str) -> None:
     if not os.path.exists(env.path):
         raise ValueError(
+            f"Non-existent venv: {env._name}. "
             "The venv must be created before running the 'fix_requirements' action. "
             "Did you forget to run 'travel setup'?"
         )
@@ -30,16 +29,37 @@ def _fix_requirements(bag: Bag, python: Python, config: TaskConfig) -> None:
     with open(env.requirements_file, "rt") as f:
         requirements = f.read().splitlines()
         
-    if PyPI_keyrings_google_artifact_registry_auth not in requirements:
+    has_keyrings = False
+    
+    for requirement in requirements:
+        if PyPI_keyrings_google_artifact_registry_auth in requirement:
+            has_keyrings = True
+            break
+
+    if not has_keyrings:
         requirements.append(PyPI_keyrings_google_artifact_registry_auth)
         
-    index_url = _get_index_url(config) + "simple"
     requirements.insert(0, f"--extra-index-url {index_url}")
     
     with open(env.requirements_file, "wt") as f:
         for requirement in requirements:
             f.write(f"{requirement}\n")
 
+
+def _fix_requirements(bag: Bag, python: Python, config: TaskConfig) -> None:
+    index_url = _get_index_url(config) + "simple"
+    
+    # It fixes the main venv
+    env = Virtualenv(bag)
+    _fix_venv_requirements(env, index_url)
+    
+    if bag.scopes:
+        scopes = ScopedVirtualenvs(bag)
+        
+        # It fixes scoped venvs
+        for scoped_env in scopes.envs.values():
+            _fix_venv_requirements(scoped_env, index_url)
+ 
 
 def _install(bag: Bag, python: Python, config: TaskConfig):
 

--- a/src/traveltask_google_artifact_registry/package/traveltask_google_artifact_registry/task.py
+++ b/src/traveltask_google_artifact_registry/package/traveltask_google_artifact_registry/task.py
@@ -34,7 +34,7 @@ def _fix_requirements(bag: Bag, python: Python, config: TaskConfig) -> None:
         requirements.append(PyPI_keyrings_google_artifact_registry_auth)
         
     index_url = _get_index_url(config) + "simple"
-    requirements.append(f"--extra-index-url {index_url}")
+    requirements.insert(0, f"--extra-index-url {index_url}")
     
     with open(env.requirements_file, "wt") as f:
         for requirement in requirements:

--- a/src/traveltask_google_artifact_registry/package/traveltask_google_artifact_registry/task.py
+++ b/src/traveltask_google_artifact_registry/package/traveltask_google_artifact_registry/task.py
@@ -47,7 +47,7 @@ def _fix_venv_requirements(env: BaseVirtualenv, index_url: str) -> None:
 
 
 def _fix_requirements(bag: Bag, python: Python, config: TaskConfig) -> None:
-    index_url = _get_index_url(config) + "simple"
+    index_url = _get_index_url(config) + "simple/"
     
     # It fixes the main venv
     env = Virtualenv(bag)


### PR DESCRIPTION
In its current state, the Travel task creates incomplete `requirements.txt` files if used before a `travel setup` command, leaving it to the user to remember to always indicate the `--extra-index-url` argument to `pip install` whenever installing a package developed with Travel.

This PR adds a `fix_requirements` action that should be used in the `post` stage injecting that info in each `requirements.txt`